### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/DateTime/Format/W3CDTF.pm6
+++ b/lib/DateTime/Format/W3CDTF.pm6
@@ -2,7 +2,7 @@
 
 use v6;
 
-class DateTime::Format::W3CDTF;
+unit class DateTime::Format::W3CDTF;
 
 method parse (Str $str) of DateTime {
     my Str $date-str = $str;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.