### PR TITLE
Fix failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Makefile
 blib/*
 *.swp
+lib/.precomp

--- a/t/main.t
+++ b/t/main.t
@@ -66,5 +66,5 @@ ok($w3c.format(DateTime.new('2012-04-05T06:07:08+1234')) eq '2012-04-05T06:07:08
 ok($w3c.format(DateTime.new('2012-04-05T06:07:08-1234')) eq '2012-04-05T06:07:08-12:34');
 ok($w3c.format(DateTime.new('2012-04-05T06:07:08+0000')) eq '2012-04-05T06:07:08Z');
 
-done;
+done-testing;
 


### PR DESCRIPTION
Christmas Perl 6 uses done-testing instead of done. Also, it creates precomp files, so I popped that directory into ignore too.